### PR TITLE
Feat/files - 파일 삭제 로직 추가 및 리뷰 수정 리팩토링

### DIFF
--- a/src/main/java/com/jp/backend/auth/config/SecurityConfig.java
+++ b/src/main/java/com/jp/backend/auth/config/SecurityConfig.java
@@ -95,8 +95,6 @@ public class SecurityConfig {
 					.requestMatchers(
 						AUTHORIZED_URLS
 					).authenticated()
-					// .requestMatchers("/profile/upload", HttpMethod.POST.name()).authenticated()
-					// .requestMatchers(new AntPathRequestMatcher("/profile/delete", HttpMethod.DELETE.name())).authenticated()
 					.anyRequest().permitAll()
 			)//여기부터 추가
 			.logout(logout -> logout

--- a/src/main/java/com/jp/backend/domain/file/controller/FileController.java
+++ b/src/main/java/com/jp/backend/domain/file/controller/FileController.java
@@ -53,8 +53,8 @@ public class FileController {
 			throw new CustomLogicException(ExceptionCode.FILE_NOT_SUPPORTED);
 		}
 
-		// 파일이 비어있거나 두개 이상인 경우
-		if (file.getSize() > 1 || file.isEmpty()) {
+		// 파일이 비어있는 경우
+		if (file.isEmpty()) {
 			throw new CustomLogicException(ExceptionCode.INVALID_ELEMENT);
 		}
 

--- a/src/main/java/com/jp/backend/domain/file/controller/FileController.java
+++ b/src/main/java/com/jp/backend/domain/file/controller/FileController.java
@@ -2,6 +2,7 @@ package com.jp.backend.domain.file.controller;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -55,7 +57,7 @@ public class FileController {
 
 		// 파일이 비어있는 경우
 		if (file.isEmpty()) {
-			throw new CustomLogicException(ExceptionCode.INVALID_ELEMENT);
+			throw new CustomLogicException(ExceptionCode.FILE_NONE);
 		}
 
 		return ResponseEntity.ok().body(new SingleResponse<>(fileService.uploadProfile(file, principal.getUsername())));
@@ -82,5 +84,27 @@ public class FileController {
 
 		return ResponseEntity.ok(new SingleResponse<>(fileService.processFileUpload(files, category, placeId, email)));
 	}
+
+	@DeleteMapping(value = "delete/files/{category}/{targetId}")
+	@Operation(summary = "파일을 삭제합니다.")
+	public ResponseEntity<Void> deleteProfile(
+		@PathVariable(value = "category") @Parameter(description = "삭제할 파일의 카테고리") UploadCategory category,
+		@PathVariable(value = "targetId") @Parameter(description = "삭제할 파일의 Id") String targetId,
+		@RequestBody Set<String> fileIds,
+		@AuthenticationPrincipal UserPrincipal principal) {
+
+		String email = (category == UploadCategory.PLACE) ? null : principal.getUsername();
+		fileService.deleteFiles(category, targetId, fileIds, email);
+
+		return ResponseEntity.noContent().build();
+	}
+
+	// TODO 사진 수정하는 기능
+	//   PLACE --> 직접 controller 만들어줘야함
+	//   REVIEW/DIARY --> 이거 수정하는 메서드 안에서 같이 받아서 그걸로 해야할듯
+
+	// 리뷰 response에 file id도 같이 보내도록
+	// 사진 삭제 api 만들어야함
+	// 리뷰 사진 업데이트할 때 api 순서는 1.사진 삭제 (혹은 안함) / 2.추가할 사진 업로드 / 3.프론트에서 리뷰에 업로드할 파일 id list 다 보냄 / 4.백엔드에서 파일 그걸로 갈아끼움
 
 }

--- a/src/main/java/com/jp/backend/domain/file/entity/File.java
+++ b/src/main/java/com/jp/backend/domain/file/entity/File.java
@@ -20,12 +20,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Getter
+@Setter
 public class File {
 	@Id
 	@GeneratedValue(generator = "uuid2")

--- a/src/main/java/com/jp/backend/domain/file/entity/FileReference.java
+++ b/src/main/java/com/jp/backend/domain/file/entity/FileReference.java
@@ -1,0 +1,5 @@
+package com.jp.backend.domain.file.entity;
+
+public interface FileReference { // 참조 파일 한번에 불러오기 위함
+	File getFile();
+}

--- a/src/main/java/com/jp/backend/domain/file/entity/PlaceFile.java
+++ b/src/main/java/com/jp/backend/domain/file/entity/PlaceFile.java
@@ -36,4 +36,6 @@ public class PlaceFile implements FileReference {
 	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	@JoinColumn(name = "file_id", nullable = false)
 	private File file;
+
+	private Integer fileOrder; // 업로드되는 순서 (조회 시 순서 똑같이 보이도록)
 }

--- a/src/main/java/com/jp/backend/domain/file/entity/PlaceFile.java
+++ b/src/main/java/com/jp/backend/domain/file/entity/PlaceFile.java
@@ -2,6 +2,7 @@ package com.jp.backend.domain.file.entity;
 
 import com.jp.backend.domain.place.entity.Place;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -23,7 +24,7 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "place_file")
-public class PlaceFile {
+public class PlaceFile implements FileReference {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -32,7 +33,7 @@ public class PlaceFile {
 	@JoinColumn(name = "place_id", nullable = false)
 	private Place place;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	@JoinColumn(name = "file_id", nullable = false)
 	private File file;
 }

--- a/src/main/java/com/jp/backend/domain/file/entity/ReviewFile.java
+++ b/src/main/java/com/jp/backend/domain/file/entity/ReviewFile.java
@@ -38,4 +38,6 @@ public class ReviewFile implements FileReference {
 	@JoinColumn(name = "file_id", nullable = false)
 	private File file;
 
+	private Integer fileOrder; // 업로드되는 순서 (조회 시 순서 똑같이 보이도록)
+
 }

--- a/src/main/java/com/jp/backend/domain/file/entity/ReviewFile.java
+++ b/src/main/java/com/jp/backend/domain/file/entity/ReviewFile.java
@@ -1,8 +1,21 @@
 package com.jp.backend.domain.file.entity;
 
 import com.jp.backend.domain.review.entity.Review;
-import jakarta.persistence.*;
-import lombok.*;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -11,18 +24,18 @@ import lombok.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Table(name = "review_file")
-public class ReviewFile {
+public class ReviewFile implements FileReference {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "review_id", nullable = false)
-    private Review review;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "review_id", nullable = false)
+	private Review review;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "file_id", nullable = false)
-    private File file;
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@JoinColumn(name = "file_id", nullable = false)
+	private File file;
 
 }

--- a/src/main/java/com/jp/backend/domain/file/repository/JpaPlaceFileRepository.java
+++ b/src/main/java/com/jp/backend/domain/file/repository/JpaPlaceFileRepository.java
@@ -1,8 +1,11 @@
 package com.jp.backend.domain.file.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.jp.backend.domain.file.entity.PlaceFile;
 
 public interface JpaPlaceFileRepository extends JpaRepository<PlaceFile, Long> {
+	List<PlaceFile> findByPlace_PlaceId(String placeId);
 }

--- a/src/main/java/com/jp/backend/domain/file/repository/JpaReviewFileRepository.java
+++ b/src/main/java/com/jp/backend/domain/file/repository/JpaReviewFileRepository.java
@@ -7,5 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.jp.backend.domain.file.entity.ReviewFile;
 
 public interface JpaReviewFileRepository extends JpaRepository<ReviewFile, Long> {
-	List<ReviewFile> findByReviewId(Long reviewId);
+	List<ReviewFile> findByReviewIdOrderByFileOrder(Long reviewId);
+
+	int countByReviewId(Long reviewId);
 }

--- a/src/main/java/com/jp/backend/domain/file/service/FileService.java
+++ b/src/main/java/com/jp/backend/domain/file/service/FileService.java
@@ -3,6 +3,7 @@ package com.jp.backend.domain.file.service;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import org.springframework.web.multipart.MultipartFile;
 
@@ -30,5 +31,5 @@ public interface FileService {
 
 	void deleteFiles(UploadCategory category, String targetId, Set<String> fileIds, String email);
 
-	File verifyFile(String fileId);
+	File verifyFile(UUID fileId);
 }

--- a/src/main/java/com/jp/backend/domain/file/service/FileService.java
+++ b/src/main/java/com/jp/backend/domain/file/service/FileService.java
@@ -2,6 +2,7 @@ package com.jp.backend.domain.file.service;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,6 +27,8 @@ public interface FileService {
 	List<FileResDto> uploadFilesForPlace(List<MultipartFile> files, String placeId);
 
 	FileResDto uploadFileForPlace(MultipartFile file, String placeId) throws IOException;
+
+	void deleteFiles(UploadCategory category, String targetId, Set<String> fileIds, String email);
 
 	File verifyFile(String fileId);
 }

--- a/src/main/java/com/jp/backend/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/com/jp/backend/domain/file/service/FileServiceImpl.java
@@ -5,14 +5,19 @@ import static com.jp.backend.domain.file.enums.FileCategory.*;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.jp.backend.domain.file.dto.FileResDto;
 import com.jp.backend.domain.file.entity.File;
+import com.jp.backend.domain.file.entity.FileReference;
 import com.jp.backend.domain.file.entity.PlaceFile;
+import com.jp.backend.domain.file.entity.ReviewFile;
 import com.jp.backend.domain.file.enums.FileCategory;
 import com.jp.backend.domain.file.enums.UploadCategory;
 import com.jp.backend.domain.file.repository.JpaFileRepository;
@@ -89,9 +94,10 @@ public class FileServiceImpl implements FileService {
 			String fileUrl = user.getProfile().getUrl();
 			String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1); // 최종 슬래시 이후의 문자열이 파일 이름
 
-			fileRepository.delete(user.getProfile()); // 파일 레포에서 삭제
 			user.setProfile(null); // 프로필 null로 설정
 			// s3Uploader.deleteFile(fileName); // TODO S3에서 삭제 안되는 거 해결
+		} else {
+			throw new CustomLogicException(ExceptionCode.FILE_NONE);
 		}
 	}
 
@@ -163,6 +169,7 @@ public class FileServiceImpl implements FileService {
 	public FileResDto uploadFileForPlace(MultipartFile file, String placeId) throws IOException {
 
 		File fileEntity = uploadFile(file, PLACE, null);
+		fileEntity.setPlace(placeService.verifyPlace(placeId));  // placeId로 Place 엔티티 찾아서 설정
 		fileRepository.save(fileEntity);
 
 		// PlaceFile에 파일 연결
@@ -206,6 +213,64 @@ public class FileServiceImpl implements FileService {
 		throw new CustomLogicException(ExceptionCode.FILE_NOT_SUPPORTED);
 	}
 
+	@Override
+	@Transactional
+	public void deleteFiles(UploadCategory category, String targetId, Set<String> fileIds, String email) {
+		if (category != UploadCategory.PLACE) {
+			userService.verifyUser(email);
+		}
+
+		// fileIds UUID Set으로 변환
+		Set<UUID> fileIdSet = fileIds.stream()
+			.map(UUID::fromString)
+			.collect(Collectors.toSet());
+
+		// category에 따라 삭제 로직 분기
+		switch (category) {
+			case REVIEW -> deleteReviewFiles(targetId, fileIdSet);
+			// case DIARY -> deleteDiaryFiles(targetId, fileIdSet);
+			case PLACE -> deletePlaceFiles(targetId, fileIdSet);
+			default -> throw new CustomLogicException(ExceptionCode.INVALID_ELEMENT);
+		}
+	}
+
+	// 리뷰 파일 삭제
+	private void deleteReviewFiles(String reviewId, Set<UUID> fileIds) {
+		List<ReviewFile> reviewFiles = reviewFileRepository.findByReviewId(Long.parseLong(reviewId));
+		deleteFilesByCategory(reviewFiles, fileIds, reviewFileRepository);
+	}
+
+	// TODO 여행기 파일 삭제
+	// private void deleteDiaryFiles(String diaryId, Set<UUID> fileIds) {
+	// 	List<DiaryFile> diaryFiles = diaryFileRepository.findByDiaryId(Long.parseLong(diaryId));
+	// 	deleteFilesByCategory(diaryFiles, fileIds, diaryFileRepository);
+	// }
+
+	// 장소 파일 삭제
+	private void deletePlaceFiles(String placeId, Set<UUID> fileIds) {
+		List<PlaceFile> placeFiles = placeFileRepository.findByPlace_PlaceId(placeId);
+		deleteFilesByCategory(placeFiles, fileIds, placeFileRepository);
+	}
+
+	// 공통 삭제 로직
+	private <T extends FileReference> void deleteFilesByCategory(List<T> fileReferences, Set<UUID> fileIds,
+		JpaRepository<T, ?> repository) {
+		List<T> filesToDelete = fileReferences.stream()
+			.filter(ref -> fileIds.contains(ref.getFile().getId()))
+			.toList();
+
+		if (!filesToDelete.isEmpty()) {
+			repository.deleteAll(filesToDelete);
+
+			// TODO S3에서 파일 삭제
+			// filesToDelete.forEach(fileRef -> {
+			// 	String fileName = fileRef.getFile().getUrl().substring(fileRef.getFile().getUrl().lastIndexOf("/") + 1);
+			// 	s3Uploader.deleteFile(fileName);
+			// });
+		}
+	}
+
+	// 검증 로직
 	@Override
 	public File verifyFile(String fileId) {
 		return fileRepository.findById(UUID.fromString(fileId))

--- a/src/main/java/com/jp/backend/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/com/jp/backend/domain/file/service/FileServiceImpl.java
@@ -86,11 +86,12 @@ public class FileServiceImpl implements FileService {
 		User user = userService.verifyUser(email);
 
 		if (user.getProfile() != null) {
-			user.setProfile(null);
-
 			String fileUrl = user.getProfile().getUrl();
 			String fileName = fileUrl.substring(fileUrl.lastIndexOf("/") + 1); // 최종 슬래시 이후의 문자열이 파일 이름
-			s3Uploader.deleteFile(fileName); // TODO S3에서 삭제 안되는 거 해결
+
+			fileRepository.delete(user.getProfile()); // 파일 레포에서 삭제
+			user.setProfile(null); // 프로필 null로 설정
+			// s3Uploader.deleteFile(fileName); // TODO S3에서 삭제 안되는 거 해결
 		}
 	}
 

--- a/src/main/java/com/jp/backend/domain/file/service/FileServiceImpl.java
+++ b/src/main/java/com/jp/backend/domain/file/service/FileServiceImpl.java
@@ -172,11 +172,14 @@ public class FileServiceImpl implements FileService {
 		fileEntity.setPlace(placeService.verifyPlace(placeId));  // placeId로 Place 엔티티 찾아서 설정
 		fileRepository.save(fileEntity);
 
+		int order = 0; // 파일 순서
+
 		// PlaceFile에 파일 연결
 		Place place = placeService.verifyPlace(placeId);
 		PlaceFile placeFile = new PlaceFile();
 		placeFile.setFile(fileEntity);
 		placeFile.setPlace(place);
+		placeFile.setFileOrder(order++);
 		placeFileRepository.save(placeFile);
 
 		return new FileResDto(fileEntity.getId().toString(), fileEntity.getUrl());
@@ -236,7 +239,7 @@ public class FileServiceImpl implements FileService {
 
 	// 리뷰 파일 삭제
 	private void deleteReviewFiles(String reviewId, Set<UUID> fileIds) {
-		List<ReviewFile> reviewFiles = reviewFileRepository.findByReviewId(Long.parseLong(reviewId));
+		List<ReviewFile> reviewFiles = reviewFileRepository.findByReviewIdOrderByFileOrder(Long.parseLong(reviewId));
 		deleteFilesByCategory(reviewFiles, fileIds, reviewFileRepository);
 	}
 
@@ -272,8 +275,8 @@ public class FileServiceImpl implements FileService {
 
 	// 검증 로직
 	@Override
-	public File verifyFile(String fileId) {
-		return fileRepository.findById(UUID.fromString(fileId))
+	public File verifyFile(UUID fileId) {
+		return fileRepository.findById(fileId)
 			.orElseThrow(() -> new CustomLogicException(ExceptionCode.FILE_NONE));
 	}
 

--- a/src/main/java/com/jp/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/jp/backend/domain/review/controller/ReviewController.java
@@ -45,14 +45,14 @@ public class ReviewController {
 		return ResponseEntity.ok(reviewService.createReview(reqDto, principal.getUsername()));
 	}
 
-	// TODO 파일 수정 가능하도록 리팩토링 / Put으로 변경
-	@Operation(summary = "리뷰 수정 API")
+	@Operation(summary = "리뷰 수정 API",
+		description = "newFileIds 필드에는 새로 추가할 파일의 id들만 넣어주세요.")
 	@PatchMapping("/review/{reviewId}")
 	public ResponseEntity<ReviewResDto> postReview(
 		@PathVariable(value = "reviewId") Long reviewId,
 		@Valid @RequestBody ReviewUpdateDto updateDto,
 		@AuthenticationPrincipal UserPrincipal principal
-	) throws Exception {
+	) {
 		return ResponseEntity.ok(reviewService.updateReview(reviewId, updateDto, principal.getUsername()));
 	}
 

--- a/src/main/java/com/jp/backend/domain/review/dto/ReviewCompactResDto.java
+++ b/src/main/java/com/jp/backend/domain/review/dto/ReviewCompactResDto.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.jp.backend.domain.file.dto.FileResDto;
 import com.jp.backend.domain.review.entity.Review;
 import com.jp.backend.domain.user.dto.UserCompactResDto;
@@ -50,6 +51,7 @@ public class ReviewCompactResDto {
 	private LocalDateTime createdAt;
 
 	@Schema(description = "리뷰의 파일 정보")
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private List<FileResDto> fileInfos;
 
 	//todo 좋아요 갯수

--- a/src/main/java/com/jp/backend/domain/review/dto/ReviewUpdateDto.java
+++ b/src/main/java/com/jp/backend/domain/review/dto/ReviewUpdateDto.java
@@ -1,5 +1,7 @@
 package com.jp.backend.domain.review.dto;
 
+import java.util.List;
+
 import com.jp.backend.domain.review.entity.Review;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -21,6 +23,9 @@ public class ReviewUpdateDto {
 
 	@Schema(description = "별점")
 	private Double star;
+
+	@Schema(description = "새로 추가할 파일아이디 리스트")
+	private List<String> newFileIds;
 
 	public Review toEntity() {
 		return Review.builder()

--- a/src/main/java/com/jp/backend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/jp/backend/domain/review/service/ReviewServiceImpl.java
@@ -180,22 +180,12 @@ public class ReviewServiceImpl implements ReviewService {
 					for (Comment comment : commentList) {
 						commentCnt += comment.getReplyList().size();
 					}
-					List<ReviewFile> reviewFiles = reviewFileRepository.findByReviewId(review.getId());
-					List<FileResDto> fileInfos = new ArrayList<>();
-					if (!reviewFiles.isEmpty()) {
-						ReviewFile firstReviewFile = reviewFiles.get(0); // 첫 번째 파일만
-						FileResDto fileInfo = new FileResDto(
-							firstReviewFile.getFile().getId().toString(),
-							firstReviewFile.getFile().getUrl()
-						);
-						fileInfos.add(fileInfo);
-					}
 
 					return ReviewCompactResDto.builder()
 						.review(review)
 						.commentCnt(commentCnt)
 						.likeCnt(likeCnt)
-						.fileInfos(fileInfos)
+						.fileInfos(null)
 						.build();
 				});
 

--- a/src/main/java/com/jp/backend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/jp/backend/domain/review/service/ReviewServiceImpl.java
@@ -2,6 +2,7 @@ package com.jp.backend.domain.review.service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -59,21 +60,7 @@ public class ReviewServiceImpl implements ReviewService {
 		Boolean visitedYn = true;
 		Review savedReview = reviewRepository.save(reqDto.toEntity(user, visitedYn));
 
-		List<FileResDto> fileInfos = new ArrayList<>();
-		// fileIds가 null이거나 비어있으면 --> 빈 리스트 반환
-		if (reqDto.getFileIds() != null && !reqDto.getFileIds().isEmpty()) {
-			for (String fileId : reqDto.getFileIds()) {
-				File file = fileService.verifyFile(fileId);
-
-				// ReviewFile에 파일 연결
-				ReviewFile reviewFile = new ReviewFile();
-				reviewFile.setFile(file);
-				reviewFile.setReview(savedReview);
-				reviewFileRepository.save(reviewFile);
-
-				fileInfos.add(new FileResDto(file.getId().toString(), file.getUrl()));
-			}
-		}
+		List<FileResDto> fileInfos = processFiles(reqDto.getFileIds(), savedReview, false);
 
 		return ReviewResDto.builder()
 			.review(savedReview)
@@ -84,21 +71,60 @@ public class ReviewServiceImpl implements ReviewService {
 
 	@Override
 	@Transactional
-	public ReviewResDto updateReview(
-		Long reviewId,
-		ReviewUpdateDto updateDto,
-		String username) {
+	public ReviewResDto updateReview(Long reviewId, ReviewUpdateDto updateDto, String username) {
 
-		User user = userService.verifyUser(username);
+		userService.verifyUser(username);
 		Review findReview = verifyReview(reviewId);
 		Review review = updateDto.toEntity();
+
 		//작성자가 아니라면 RestException
 		if (!username.equals(findReview.getUser().getEmail())) {
 			throw new CustomLogicException(ExceptionCode.FORBIDDEN);
 		}
+
+		List<FileResDto> fileInfos = new ArrayList<>();
+
+		// 기존에 연결된 파일 조회 후 fileInfos에 추가
+		List<ReviewFile> existingReviewFiles = reviewFileRepository.findByReviewIdOrderByFileOrder(reviewId);
+		for (ReviewFile reviewFile : existingReviewFiles) {
+			File file = reviewFile.getFile();
+			fileInfos.add(new FileResDto(file.getId().toString(), file.getUrl()));
+		}
+
+		// 새 파일 fileInfos에 추가
+		List<FileResDto> newFileInfos = processFiles(updateDto.getNewFileIds(), findReview, true);
+		fileInfos.addAll(newFileInfos);
+
 		Review updatingReview = beanUtils.copyNonNullProperties(review, findReview);
-		Long likeCnt = likeRepository.countLike(Like.LikeType.REVIEW, review.getId().toString(), null);
-		return ReviewResDto.builder().review(updatingReview).likeCnt(likeCnt).build();
+		Long likeCnt = likeRepository.countLike(Like.LikeType.REVIEW, findReview.getId().toString(), null);
+		return ReviewResDto.builder().review(updatingReview).likeCnt(likeCnt).fileInfos(fileInfos).build();
+	}
+
+	// reviewFile 참조 로직
+	private List<FileResDto> processFiles(List<String> fileIds, Review review, boolean isUpdate) {
+		List<FileResDto> fileInfos = new ArrayList<>();
+
+		if (fileIds != null && !fileIds.isEmpty()) {
+			int order = 0; // 파일 업로드 순서
+
+			// 리뷰 업데이트일 경우 -> 기존 파일 순서대로 order 설정
+			if (isUpdate) {
+				order = reviewFileRepository.countByReviewId(review.getId());
+			}
+
+			for (String fileId : fileIds) {
+				UUID uuid = UUID.fromString(fileId);
+				File file = fileService.verifyFile(uuid);
+				// ReviewFile에 파일 연결
+				ReviewFile reviewFile = new ReviewFile();
+				reviewFile.setFile(file);
+				reviewFile.setReview(review);
+				reviewFile.setFileOrder(order++);
+				reviewFileRepository.save(reviewFile);
+				fileInfos.add(new FileResDto(file.getId().toString(), file.getUrl()));
+			}
+		}
+		return fileInfos;
 	}
 
 	@Override
@@ -110,7 +136,7 @@ public class ReviewServiceImpl implements ReviewService {
 		Long likeCnt = likeRepository.countLike(Like.LikeType.REVIEW, reviewId.toString(), null);
 		List<Comment> commentList = commentRepository.findAllByCommentTypeAndTargetId(CommentType.REVIEW, reviewId);
 
-		List<ReviewFile> reviewFiles = reviewFileRepository.findByReviewId(reviewId);
+		List<ReviewFile> reviewFiles = reviewFileRepository.findByReviewIdOrderByFileOrder(reviewId);
 		List<FileResDto> fileInfos = getFileInfos(reviewFiles);
 
 		return ReviewResDto.builder()
@@ -139,7 +165,7 @@ public class ReviewServiceImpl implements ReviewService {
 					for (Comment comment : commentList) {
 						commentCnt += comment.getReplyList().size();
 					}
-					List<ReviewFile> reviewFiles = reviewFileRepository.findByReviewId(review.getId());
+					List<ReviewFile> reviewFiles = reviewFileRepository.findByReviewIdOrderByFileOrder(review.getId());
 					List<FileResDto> fileInfos = getFileInfos(reviewFiles);
 					return ReviewCompactResDto.builder()
 						.review(review)

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -102,7 +102,7 @@ INSERT INTO place (ID, PLACE_ID, NAME, SUB_NAME, DESCRIPTION, PLACE_TYPE, LAT, L
 VALUES (1, 'ChIJq_vvHybkYjURBDWI49gjy3U', '춘천', '강원도 춘천시',
         '춘천시는 강원도의 도청 소재지로, 소양강과 춘천호를 중심으로 아름다운 자연 경관을 자랑합니다. 닭갈비와 막국수가 유명합니다.',
         'CITY', 37.8897796, 127.7398952, 'GANGWON_DO'),
-       (2, 'ChIJX4TbvUQJaDURb8Ue9BqXAAQ', '원주', '강원도 원주시',
+       (2, 'ChIJ0x17PwR1YzURpfes2eU-Vl4', '원주', '강원도 원주시',
         '원주시는 강원도 남서부에 위치한 도시로, 혁신도시와 의료기기 산업으로 유명합니다. 치악산 국립공원이 인접해 있습니다.',
         'CITY', 37.342218, 127.920162, 'GANGWON_DO'),
        (3, 'ChIJWw9PleHlYTURRh09nFHGt4A', '강릉', '강원도 강릉',


### PR DESCRIPTION
### <구현 및 리팩토링한 기능 >
- 파일 삭제 로직 추가

- 리뷰 수정 api 리팩토링
--> PUT으로 할까 고민했었는데 리뷰 수정 시 파일의 경우에는 파일 삭제 api를 거치고 왔을테니(그럼 거기서 reviewFile의 파일 연결 끊어짐, 파일 삭제가 이미 완료됨 --> 남겨둘 파일만 존재),
새로 추가하는 파일 id들만 받는 것이 더 효율적일 것으로 판단하여 기존 PATCH 사용
> **리뷰 수정 시 실행 로직** : 파일 삭제 api -> 새 파일 업로드 api -> 리뷰 수정 api로 새 파일 id들만  백엔드로 전달 -> 백엔드에서 기존 파일은 놔두고 새 파일만 reviewFile에 저장 후, response로는 모든 파일 정보 전달

- 업로드 순서 기억을 위해 reviewFile, placeFile에 fileOrder 필드 추가
--> 리뷰 조회 시 파일은 업로드 순서 기준 오름차순으로 나타남

- 내 리뷰 list 조회 response에서 파일 제거

---
#### <참고>
- place 사진 업로드 기능은 있으나 place 사진 수정 기능은 아직 없음
( 필요해도 나중에 필요할 것이라 생각되어 완전 후순위 예정 )
